### PR TITLE
Movie/show refactor

### DIFF
--- a/app/facades/movie_facade.rb
+++ b/app/facades/movie_facade.rb
@@ -16,5 +16,4 @@ class MovieFacade
     reviews = service.request_api("/3/movie/#{movie_id}/reviews")
     @movie = MovieDetails.new(movie, cast, reviews)
   end
-
 end

--- a/app/views/authenticated/movies/index.html.erb
+++ b/app/views/authenticated/movies/index.html.erb
@@ -12,7 +12,7 @@
     <table class="movie-table">
       <% @movies.each do |movie| %>
         <tr>
-          <td><%= movie[:title] %></td>
+          <td><%= link_to movie[:title], "/movies/#{movie[:id]}" %></td>
           <td><%= movie[:vote_average] %></td>
         </tr>
       <% end %>

--- a/spec/facades/movie_facade_spec.rb
+++ b/spec/facades/movie_facade_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe 'MovieFacade' do
   describe 'class methods' do
     describe '::forty_top_rated_movies' do
       it 'returns list of top forty movies' do
-        response_body = File.read('spec/fixtures/top_rated.json')
-        stub_request(:get, "https://api.themoviedb.org/3/movie/top_rated").
-            to_return(status: 200, body: response_body, headers: {})
+        stub_forty_top_rated_movies
         movies = MovieFacade.forty_top_rated_movies
 
         expect(movies).to be_a(Array)
@@ -17,12 +15,9 @@ RSpec.describe 'MovieFacade' do
 
     describe '::search_movie_title' do
       it 'returns all movies related to query' do
-        response_body = File.read('spec/fixtures/top_rated.json')
-        stub_request(:get, "https://api.themoviedb.org/3/search/movie?query=Cruella").
-            to_return(status: 200, body: response_body, headers: {})
+        stub_search_movie_by_title 
         movies = MovieFacade.search_movie_title("Cruella")
 
-        # require "pry"; binding.pry
         expect(movies).to be_a(Array)
         expect(movies.count).to eq(5)
         expect(movies.first[:title]).to eq("Cruella")
@@ -31,9 +26,7 @@ RSpec.describe 'MovieFacade' do
 
     describe '::movie_details_by_id' do
       it 'returns all movies and details' do
-        response_body = File.read('spec/fixtures/top_rated.json')
-        stub_request(:get, "https://api.themoviedb.org/3/search/movie?query=Cruella").
-            to_return(status: 200, body: response_body, headers: {})
+        stub_movie_details_by_id
         movie = MovieFacade.movie_details_by_id(337404)
         
         expect(movie).to be_a(MovieDetails)

--- a/spec/features/authenticated/movies/index_spec.rb
+++ b/spec/features/authenticated/movies/index_spec.rb
@@ -43,16 +43,31 @@ RSpec.describe "Movies index page" do
         fill_in("query", with: "Cruella")
         click_button("Find Movies")
 
-        response_body = File.read('spec/fixtures/find_movie_by_title.json')
-        stub_request(:get, "https://api.themoviedb.org/3/search/movie?query=Cruella").
-            to_return(status: 200, body: response_body, headers: {})
+        stub_search_movie_by_title
 
-            expect(page).to_not have_content("Dilwale Dulhania Le Jayenge")
-            expect(page).to_not have_content("The Shawshank Redemption")
-            expect(page).to have_content("Cruella")
-            expect(page).to have_content("Cruella 2")
-            expect(page).to have_content("A Christmas Cruella")
-            expect(page).to have_content("Mega Mindy - Della Cruella")
+        expect(page).to_not have_content("Dilwale Dulhania Le Jayenge")
+        expect(page).to_not have_content("The Shawshank Redemption")
+        expect(page).to have_content("Cruella")
+        expect(page).to have_content("Cruella 2")
+        expect(page).to have_content("A Christmas Cruella")
+        expect(page).to have_content("Mega Mindy - Della Cruella")
+      end
+    end
+
+    context 'if user clicks movie title' do
+      it 'should link to that movie show page' do
+        expect(current_path).to eq(movies_path)
+        fill_in("query", with: "Cruella")
+        click_button("Find Movies")
+       
+        click_link "Cruella"
+        expect(current_path).to eq("/movies/337404")
+        expect(page).to have_content("Cruella")
+        expect(page).to_not have_content("Cruella 2")
+        expect(page).to have_content("Vote Average")
+        expect(page).to have_content("Runtime")
+        expect(page).to have_content("Genres")
+        expect(page).to have_content("Cast")
       end
     end
   end

--- a/spec/features/authenticated/movies/index_spec.rb
+++ b/spec/features/authenticated/movies/index_spec.rb
@@ -25,11 +25,8 @@ RSpec.describe "Movies index page" do
     context "if user clicks 'Find Top Rated Movies' button" do
       it 'should return list of top rated movies and its vote average' do
         click_button 'Find Top Rated Movies'
+        stub_forty_top_rated_movies
         
-        response_body = File.read('spec/fixtures/top_rated.json')
-        stub_request(:get, "https://api.themoviedb.org/3/movie/top_rated").
-            to_return(status: 200, body: response_body, headers: {})
-
         expect(page).to have_content("Dilwale Dulhania Le Jayenge")
         expect(page).to have_content("8.7")
         expect(page).to have_content("The Shawshank Redemption")

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User registration form" do
     email = "hi@here.com"
     password = "hello"
     password_confirmation = "hello"
-
+    
     fill_in 'user[email]', with: email
     fill_in 'user[password]', with: password
     fill_in 'user[password_confirmation]', with: password_confirmation

--- a/spec/fixtures/top_rated_2.json
+++ b/spec/fixtures/top_rated_2.json
@@ -1,0 +1,396 @@
+{
+  "page": 2,
+  "results": [
+      {
+          "adult": false,
+          "backdrop_path": "/nMKdUUepR0i5zn0y1T4CsSB5chy.jpg",
+          "genre_ids": [
+              18,
+              28,
+              80,
+              53
+          ],
+          "id": 155,
+          "original_language": "en",
+          "original_title": "The Dark Knight",
+          "overview": "Batman raises the stakes in his war on crime. With the help of Lt. Jim Gordon and District Attorney Harvey Dent, Batman sets out to dismantle the remaining criminal organizations that plague the streets. The partnership proves to be effective, but they soon find themselves prey to a reign of chaos unleashed by a rising criminal mastermind known to the terrified citizens of Gotham as the Joker.",
+          "popularity": 51.837,
+          "poster_path": "/qJ2tW6WMUDux911r6m7haRef0WH.jpg",
+          "release_date": "2008-07-16",
+          "title": "The Dark Knight",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 25407
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/tlEFuIlaxRPXIYVHXbOSAMCfWqk.jpg",
+          "genre_ids": [
+              35,
+              18,
+              10749
+          ],
+          "id": 13,
+          "original_language": "en",
+          "original_title": "Forrest Gump",
+          "overview": "A man with a low IQ has accomplished great things in his life and been present during significant historic events—in each case, far exceeding what anyone imagined he could do. But despite all he has achieved, his one true love eludes him.",
+          "popularity": 54.296,
+          "poster_path": "/h5J4W4veyxMXDMjeNxZI46TsHOb.jpg",
+          "release_date": "1994-07-06",
+          "title": "Forrest Gump",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 20825
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/x4biAVdPVCghBlsVIzB6NmbghIz.jpg",
+          "genre_ids": [
+              37
+          ],
+          "id": 429,
+          "original_language": "it",
+          "original_title": "Il buono, il brutto, il cattivo",
+          "overview": "While the Civil War rages between the Union and the Confederacy, three men – a quiet loner, a ruthless hit man and a Mexican bandit – comb the American Southwest in search of a strongbox containing $200,000 in stolen gold.",
+          "popularity": 31.662,
+          "poster_path": "/mxdjCeoPTy6IUd99nTB6kjiRiZI.jpg",
+          "release_date": "1966-12-23",
+          "title": "The Good, the Bad and the Ugly",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 5989
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/zoVeIgKzGJzpdG6Gwnr7iOYfIMU.jpg",
+          "genre_ids": [
+              18,
+              10749
+          ],
+          "id": 11216,
+          "original_language": "it",
+          "original_title": "Nuovo Cinema Paradiso",
+          "overview": "A filmmaker recalls his childhood, when he fell in love with the movies at his village's theater and formed a deep friendship with the theater's projectionist.",
+          "popularity": 18.11,
+          "poster_path": "/8SRUfRUi6x4O68n0VCbDNRa6iGL.jpg",
+          "release_date": "1988-11-17",
+          "title": "Cinema Paradiso",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 2953
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/gavyCu1UaTaTNPsVaGXT6pe5u24.jpg",
+          "genre_ids": [
+              35,
+              18
+          ],
+          "id": 637,
+          "original_language": "it",
+          "original_title": "La vita è bella",
+          "overview": "A touching story of an Italian book seller of Jewish ancestry who lives in his own little fairy tale. His creative and happy life would come to an abrupt halt when his entire family is deported to a concentration camp during World War II. While locked up he tries to convince his son that the whole thing is just a game.",
+          "popularity": 38.678,
+          "poster_path": "/74hLDKjD5aGYOotO6esUVaeISa2.jpg",
+          "release_date": "1997-12-20",
+          "title": "Life Is Beautiful",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 10275
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/1fOsyhVz5qyX2rl1qqX6KImVhTx.jpg",
+          "genre_ids": [
+              18,
+              35
+          ],
+          "id": 644479,
+          "original_language": "es",
+          "original_title": "Dedicada a mi ex",
+          "overview": "The film tells the story of Ariel, a 21-year-old who decides to form a rock band to compete for a prize of ten thousand dollars in a musical band contest, this as a last option when trying to get money to save their relationship and reunite with his ex-girlfriend, which breaks due to the trip she must make to Finland for an internship. Ariel with her friend Ortega, decides to make a casting to find the other members of the band, although they do not know nothing about music, thus forming a band with members that have diverse and opposite personalities.",
+          "popularity": 24.148,
+          "poster_path": "/riAooJrFvVhotyaOgoI0WR7okSe.jpg",
+          "release_date": "2019-11-01",
+          "title": "Dedicated to my ex",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 398
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/sJNNMCc6B7KZIY3LH3JMYJJNH5j.jpg",
+          "genre_ids": [
+              28,
+              18
+          ],
+          "id": 346,
+          "original_language": "ja",
+          "original_title": "七人の侍",
+          "overview": "A samurai answers a village's request for protection after he falls on hard times. The town needs protection from bandits, so the samurai gathers six others to help him teach the people how to defend themselves, and the villagers provide the soldiers with food.",
+          "popularity": 14.593,
+          "poster_path": "/8OKmBV5BUFzmozIC3pPWKHy17kx.jpg",
+          "release_date": "1954-04-26",
+          "title": "Seven Samurai",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 2312
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/sw7mordbZxgITU877yTpZCud90M.jpg",
+          "genre_ids": [
+              18,
+              80
+          ],
+          "id": 769,
+          "original_language": "en",
+          "original_title": "GoodFellas",
+          "overview": "The true story of Henry Hill, a half-Irish, half-Sicilian Brooklyn kid who is adopted by neighbourhood gangsters at an early age and climbs the ranks of a Mafia family under the guidance of Jimmy Conway.",
+          "popularity": 24.86,
+          "poster_path": "/6QMSLvU5ziIL2T6VrkaKzN2YkxK.jpg",
+          "release_date": "1990-09-12",
+          "title": "GoodFellas",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 9071
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/rO4pfAIIrt3N905wTTe2HrH3uUv.jpg",
+          "genre_ids": [
+              18,
+              80
+          ],
+          "id": 311,
+          "original_language": "en",
+          "original_title": "Once Upon a Time in America",
+          "overview": "A former Prohibition-era Jewish gangster returns to the Lower East Side of Manhattan over thirty years later, where he once again must confront the ghosts and regrets of his old life.",
+          "popularity": 17.162,
+          "poster_path": "/i0enkzsL5dPeneWnjl1fCWm6L7k.jpg",
+          "release_date": "1984-05-23",
+          "title": "Once Upon a Time in America",
+          "video": false,
+          "vote_average": 8.5,
+          "vote_count": 3660
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/nC3IjYhUgZWgfKfFX0ygMigFwgc.jpg",
+          "genre_ids": [
+              28,
+              18,
+              36
+          ],
+          "id": 14537,
+          "original_language": "ja",
+          "original_title": "切腹",
+          "overview": "An unusual request for ritual suicide on a feudal lord's property leads to the unwinding of a greater mystery that challenges the clan's integrity.",
+          "popularity": 13.004,
+          "poster_path": "/fRqVjso3rdEcxZHXWE2xazDAtjI.jpg",
+          "release_date": "1962-09-15",
+          "title": "Harakiri",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 495
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/m5HPKCi7GdhKmxPTcOQmcLfEmZ9.jpg",
+          "genre_ids": [
+              12,
+              35,
+              16,
+              14
+          ],
+          "id": 532067,
+          "original_language": "ja",
+          "original_title": "この素晴らしい世界に祝福を！紅伝説",
+          "overview": "It is not strange that the Demon Lord's forces fear the Crimson Demons, the clan from which Megumin and Yunyun originate. Even if the Demon Lord's generals attack their village, the Crimson Demons can just easily brush them off with their supreme mastery of advanced and overpowered magic.  When Yunyun receives a seemingly serious letter regarding a potential disaster coming to her hometown, she immediately informs Kazuma Satou and the rest of his party. After a series of wacky misunderstandings, it turns out to be a mere prank by her fellow demon who wants to be an author. Even so, Megumin becomes worried about her family and sets out toward the Crimson Demons' village with the gang.  There, Kazuma and the others decide to sightsee the wonders of Megumin's birthplace. However, they soon come to realize that the nonsense threat they received might have been more than just a joke.",
+          "popularity": 183.746,
+          "poster_path": "/j73LuQcA21KvkVFcroWWMN8tTJv.jpg",
+          "release_date": "2019-08-30",
+          "title": "KonoSuba: God's Blessing on this Wonderful World! Legend of Crimson",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 277
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/uWVkEo9PWHu9algZsiLPi6sRU64.jpg",
+          "genre_ids": [
+              10402,
+              36,
+              18
+          ],
+          "id": 556574,
+          "original_language": "en",
+          "original_title": "Hamilton",
+          "overview": "Presenting the tale of American founding father Alexander Hamilton, this filmed version of the original Broadway smash hit is the story of America then, told by America now.",
+          "popularity": 16.265,
+          "poster_path": "/h1B7tW0t399VDjAcWJh8m87469b.jpg",
+          "release_date": "2020-07-03",
+          "title": "Hamilton",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 758
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/kZGaVeXSkkvrpMYvD97sxHj291k.jpg",
+          "genre_ids": [
+              27,
+              18,
+              53
+          ],
+          "id": 539,
+          "original_language": "en",
+          "original_title": "Psycho",
+          "overview": "When larcenous real estate clerk Marion Crane goes on the lam with a wad of cash and hopes of starting a new life, she ends up at the notorious Bates Motel, where manager Norman Bates cares for his housebound mother.",
+          "popularity": 26.486,
+          "poster_path": "/5j5tdV8tMTy7FBdSNiYxp9Fj1Or.jpg",
+          "release_date": "1960-06-22",
+          "title": "Psycho",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 7425
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/pcDc2WJAYGJTTvRSEIpRZwM3Ola.jpg",
+          "genre_ids": [
+              28,
+              12,
+              14,
+              878
+          ],
+          "id": 791373,
+          "original_language": "en",
+          "original_title": "Zack Snyder's Justice League",
+          "overview": "Determined to ensure Superman's ultimate sacrifice was not in vain, Bruce Wayne aligns forces with Diana Prince with plans to recruit a team of metahumans to protect the world from an approaching threat of catastrophic proportions.",
+          "popularity": 782.356,
+          "poster_path": "/tnAuB8q5vv7Ax9UAEje5Xi4BXik.jpg",
+          "release_date": "2021-03-18",
+          "title": "Zack Snyder's Justice League",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 6009
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/6MKr3KgOLmzOP6MSuZERO41Lpkt.jpg",
+          "genre_ids": [
+              28,
+              35
+          ],
+          "id": 337404,
+          "original_language": "en",
+          "original_title": "Cruella",
+          "overview": "In 1970s London amidst the punk rock revolution, a young grifter named Estella is determined to make a name for herself with her designs. She befriends a pair of young thieves who appreciate her appetite for mischief, and together they are able to build a life for themselves on the London streets. One day, Estella’s flair for fashion catches the eye of the Baroness von Hellman, a fashion legend who is devastatingly chic and terrifyingly haute. But their relationship sets in motion a course of events and revelations that will cause Estella to embrace her wicked side and become the raucous, fashionable and revenge-bent Cruella.",
+          "popularity": 1996.876,
+          "poster_path": "/rTh4K5uw9HypmpGslcKd4QfHl93.jpg",
+          "release_date": "2021-05-26",
+          "title": "Cruella",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 3975
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/y0SiXoTLQp93NbLQ4XhgVz18UAS.jpg",
+          "genre_ids": [
+              16,
+              28,
+              14
+          ],
+          "id": 663558,
+          "original_language": "en",
+          "original_title": "NE ZHA Reborn",
+          "overview": "3000 years after the boy-god Nezha conquers the Dragon King then disappears in mythological times, he returns as an ordinary man to find his own path to becoming a true hero.",
+          "popularity": 339.619,
+          "poster_path": "/6goDkAD6J3br81YMQf0Gat8Bqjy.jpg",
+          "release_date": "2021-02-06",
+          "title": "New Gods: Nezha Reborn",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 201
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/bx326cwBtDsfDcnTgFlK5dXkyaC.jpg",
+          "genre_ids": [
+              10402,
+              18,
+              10749
+          ],
+          "id": 630566,
+          "original_language": "en",
+          "original_title": "Clouds",
+          "overview": "Young musician Zach Sobiech discovers his cancer has spread, leaving him just a few months to live. With limited time, he follows his dream and makes an album, unaware that it will soon be a viral music phenomenon.",
+          "popularity": 13.044,
+          "poster_path": "/d0OdD1I8qAfETvE9Rp9Voq7R8LR.jpg",
+          "release_date": "2020-10-09",
+          "title": "Clouds",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 707
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/rr7E0NoGKxvbkb89eR1GwfoYjpA.jpg",
+          "genre_ids": [
+              18
+          ],
+          "id": 550,
+          "original_language": "en",
+          "original_title": "Fight Club",
+          "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground \"fight clubs\" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion.",
+          "popularity": 42.874,
+          "poster_path": "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
+          "release_date": "1999-10-15",
+          "title": "Fight Club",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 21997
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/3KwAmIKMaDcBMonF5wmyNTL0SR6.jpg",
+          "genre_ids": [
+              18
+          ],
+          "id": 510,
+          "original_language": "en",
+          "original_title": "One Flew Over the Cuckoo's Nest",
+          "overview": "While serving time for insanity at a state mental hospital, implacable rabble-rouser, Randle Patrick McMurphy, inspires his fellow patients to rebel against the authoritarian rule of head nurse, Mildred Ratched.",
+          "popularity": 17.457,
+          "poster_path": "/3jcbDmRFiQ83drXNOvRDeKHxS0C.jpg",
+          "release_date": "1975-11-18",
+          "title": "One Flew Over the Cuckoo's Nest",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 7866
+      },
+      {
+          "adult": false,
+          "backdrop_path": "/q5HZvtyqG8Vz39Ee9uTQbLeEml.jpg",
+          "genre_ids": [
+              16,
+              18
+          ],
+          "id": 378064,
+          "original_language": "ja",
+          "original_title": "映画 聲の形",
+          "overview": "Shouya Ishida starts bullying the new girl in class, Shouko Nishimiya, because she is deaf. But as the teasing continues, the rest of the class starts to turn on Shouya for his lack of compassion. When they leave elementary school, Shouko and Shouya do not speak to each other again... until an older, wiser Shouya, tormented by his past behaviour, decides he must see Shouko once more. He wants to atone for his sins, but is it already too late...?",
+          "popularity": 114.744,
+          "poster_path": "/tuFaWiqX0TXoWu7DGNcmX3UW7sT.jpg",
+          "release_date": "2016-09-17",
+          "title": "A Silent Voice: The Movie",
+          "video": false,
+          "vote_average": 8.4,
+          "vote_count": 2437
+      }
+  ],
+  "total_pages": 445,
+  "total_results": 8898
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,3 +98,33 @@ RSpec.configure do |config|
 =end
 end
 require 'webmock/rspec'
+
+def stub_forty_top_rated_movies 
+  response_body = File.read('spec/fixtures/top_rated.json')
+  stub_request(:get, "https://api.themoviedb.org/3/movie/top_rated&page=1").
+      to_return(status: 200, body: response_body, headers: {})
+
+  response_body = File.read('spec/fixtures/top_rated_2.json')
+    stub_request(:get, "https://api.themoviedb.org/3/movie/top_rated&page=2").
+      to_return(status: 200, body: response_body, headers: {}) 
+end
+
+def stub_search_movie_by_title 
+  response_body = File.read('spec/fixtures/find_movie_by_title.json')
+  stub_request(:get, "https://api.themoviedb.org/3/search/movie?query=Cruella").
+      to_return(status: 200, body: response_body, headers: {})
+end
+
+def stub_movie_details_by_id
+  response_body = File.read('spec/fixtures/find_cast_by_id.json')
+    stub_request(:get, "https://api.themoviedb.org/3/movie/337404/credits").
+      to_return(status: 200, body: response_body, headers: {})
+
+  response_body = File.read('spec/fixtures/find_reviews.json')
+    stub_request(:get, "https://api.themoviedb.org/3/movie/337404/reviews").
+      to_return(status: 200, body: response_body, headers: {})
+
+  response_body = File.read('spec/fixtures/find_movie_by_id.json')
+    stub_request(:get, "https://api.themoviedb.org/3/movie/337404").
+      to_return(status: 200, body: response_body, headers: {})
+  end


### PR DESCRIPTION
This PR request refactors the Webmock stub methods that were used in several test. It also adds the spec test and functionality to link out to movie show pages from the index page. 

Neccesary checkmarks:

    [x] All Tests are Passing

    [x] The code will run locally

Type of change

    [x] New feature
    [] Bug Fix

Implements/Fixes:
closes #8 
closes #9 

Check the correct boxes

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

Testing Changes

    [x] No Tests have been changed
    [] Some Tests have been changed
    [] All of the Tests have been changed(Please describe what in the world happened)

Checklist:

    [x] My code has no unused/commented out code
    [x] I have reviewed my code
    [x] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code